### PR TITLE
Drop duplicate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 tokio = { version = "0.2", features = ["full"] }
 reqwest = { version = "0.10", features = ["json", "cookies", "gzip"] }
 async-std = { version = "1.5.0", features = ["attributes"] }
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 serde = { version = "1", features = ["derive"] }
 roa = { path = "./roa", features = ["full"] }
 test-case = "1.0.0"

--- a/integration/diesel-example/Cargo.toml
+++ b/integration/diesel-example/Cargo.toml
@@ -13,7 +13,7 @@ roa-diesel = { path = "../../roa-diesel" }
 async-std = { version = "1.4", features = ["attributes"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/integration/multipart-example/Cargo.toml
+++ b/integration/multipart-example/Cargo.toml
@@ -11,5 +11,5 @@ roa = { path = "../../roa", features = ["router", "file"] }
 roa-multipart = { path = "../../roa-multipart" }
 async-std = { version = "1.5", features = ["attributes"] }
 log = "0.4"
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 futures = "0.3"

--- a/integration/websocket-example/Cargo.toml
+++ b/integration/websocket-example/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 roa = { path = "../../roa", features = ["router", "file", "websocket"] }
 async-std = { version = "1.5", features = ["attributes"] }
 log = "0.4"
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 futures = "0.3"
 http = "0.2"
 slab = "0.4.2"

--- a/roa/Cargo.toml
+++ b/roa/Cargo.toml
@@ -72,7 +72,7 @@ tokio-tls = "0.3.0"
 hyper-tls = "0.4.1"
 reqwest = { version = "0.10", features = ["json", "cookies", "gzip"] }
 async-std = { version = "1.5.0", features = ["attributes"] }
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 serde = { version = "1", features = ["derive"] }
 test-case = "1.0.0"
 slab = "0.4.2"


### PR DESCRIPTION
We now pull two versions `pretty_env_logger`, it'd be great if we could drop old one.